### PR TITLE
#54 Fix typo in terraformrc and modify build_provider script to retur…

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,7 +5,7 @@ provider "local.providers/local/terratowns" {
   version     = "1.0.0"
   constraints = "1.0.0"
   hashes = [
-    "h1:bDn0SuwUe2wXQPEAd6XI4L0PtEB/VyoJrpi5HYE2co4=",
+    "h1:LEm60jmnm44AoaSr4m60qGnhsr/baCPvP/ipfuCJVHg=",
   ]
 }
 

--- a/bin/build_provider
+++ b/bin/build_provider
@@ -15,3 +15,6 @@ mkdir -p $PLUGIN_DIR/x86_64/
 mkdir -p $PLUGIN_DIR/linux_amd64/
 cp $PROJECT_ROOT/terraform-provider-terratowns/$PLUGIN_NAME $PLUGIN_DIR/x86_64
 cp $PROJECT_ROOT/terraform-provider-terratowns/$PLUGIN_NAME $PLUGIN_DIR/linux_amd64
+
+# Go back to project root directory.
+cd $PROJECT_ROOT

--- a/terraformrc
+++ b/terraformrc
@@ -1,4 +1,4 @@
-provider_installations {
+provider_installation {
     filesystem_mirror {
         path = "/home/gitpod/.terraform.d/plugins"
         include = ["local.providers/*/*"]


### PR DESCRIPTION
…n to project_root.

- [x] Fix typo in `terraformrc` file:
  Should be:
  ```terraform
  provider_installation {
    …
  }
  ```
- [x] Update `build_provider` script to return to `$PROJECT_ROOT` when complete.